### PR TITLE
Updated the use of libcups

### DIFF
--- a/cnijfilter-3.80-1.libraries.patch
+++ b/cnijfilter-3.80-1.libraries.patch
@@ -10,8 +10,8 @@ diff -rupN cnijfilter-source-3.80-1.orig/backend/src/cnij_backend_common.c cnijf
  // Header file for CANON
  #include "cnij_backend_common.h"
 diff -rupN cnijfilter-source-3.80-1.orig/cngpij/cngpij/bjcups.c cnijfilter-source-3.80-1/cngpij/cngpij/bjcups.c
---- cnijfilter-source-3.80-1.orig/cngpij/cngpij/bjcups.c	2012-04-17 06:39:20.000000000 +0300
-+++ cnijfilter-source-3.80-1/cngpij/cngpij/bjcups.c	2014-12-13 17:23:22.000000000 +0200
+--- cnijfilter-source-3.80-1.orig/cngpij/cngpij/bjcups.c	2012-04-17 07:39:20.000000000 +0400
++++ cnijfilter-source-3.80-1/cngpij/cngpij/bjcups.c	2020-12-05 21:02:48.010581813 +0300
 @@ -21,6 +21,7 @@
  #include	<config.h>
  #endif	// HAVE_CONFIG_H
@@ -20,9 +20,74 @@ diff -rupN cnijfilter-source-3.80-1.orig/cngpij/cngpij/bjcups.c cnijfilter-sourc
  #include <cups/cups.h>
  #include <cups/language.h>
  #include <cups/ppd.h>
+@@ -697,10 +698,10 @@ static short getDeviceURI( const char *p
+ 	}
+ 	else {
+ 		pRequest = ippNew();
+-
+-		pRequest->request.op.operation_id = CUPS_GET_PRINTERS;
+-		pRequest->request.op.request_id   = 1;
+-
++
++		ippSetOperation(pRequest, CUPS_GET_PRINTERS);
++		ippSetRequestId(pRequest, 1);
++
+ 		pLanguage = bjcupsLangDefault();	// cupsLangDefault() -> bjcupsLangDefault() for cups-1.1.19
+
+ 		ippAddString(pRequest, IPP_TAG_OPERATION, IPP_TAG_CHARSET, "attributes-charset", NULL, cupsLangEncoding(pLanguage));
+@@ -708,29 +709,29 @@ static short getDeviceURI( const char *p
+ 		ippAddString(pRequest, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri", NULL, NULL);
+
+ 		if ((pResponse = cupsDoRequest(pHTTP, pRequest, "/")) != NULL) {
+-			if (pResponse->request.status.status_code > IPP_OK_CONFLICT) {
++			if (ippGetStatusCode(pResponse) > IPP_OK_CONFLICT) {
+ 				fputs("ERROR: IPP ERROR\n", stderr);
+ 				goto onErr;
+ 			}
+ 			else {
+-				pAttribute = pResponse->attrs;
++				pAttribute = ippFirstAttribute(pResponse);
+
+ 				while (pAttribute != NULL) {
+-					while (pAttribute != NULL && pAttribute->group_tag != IPP_TAG_PRINTER) {
+-						pAttribute = pAttribute->next;
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) != IPP_TAG_PRINTER) {
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+ 					if (pAttribute == NULL) {
+ 						break;
+ 					}
+-
+-					while (pAttribute != NULL && pAttribute->group_tag == IPP_TAG_PRINTER) {
+-						if (strcmp(pAttribute->name, "printer-name") == 0 && pAttribute->value_tag == IPP_TAG_NAME) {
+-							pPrinter = pAttribute->values[0].string.text;
++
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) == IPP_TAG_PRINTER) {
++						if (strcmp(ippGetName(pAttribute), "printer-name") == 0 && ippGetValueTag(pAttribute) == IPP_TAG_NAME) {
++							pPrinter = ippGetString(pAttribute, 0, pLanguage);
+ 						}
+-						if (strcmp(pAttribute->name, "device-uri") == 0 && pAttribute->value_tag == IPP_TAG_URI) {
+-							pDUri = pAttribute->values[0].string.text;
++						if (strcmp(ippGetName(pAttribute), "device-uri") == 0 && ippGetValueTag(pAttribute)  == IPP_TAG_URI) {
++							pDUri = ippGetString(pAttribute, 0, pLanguage);
+ 						}
+-						pAttribute = pAttribute->next;
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+
+ 					if (strcasecmp(pDestName, pPrinter) == 0) {
+@@ -739,7 +740,7 @@ static short getDeviceURI( const char *p
+ 					}
+
+ 					if (pAttribute != NULL)
+-						 pAttribute = pAttribute->next;
++						pAttribute = ippNextAttribute(pResponse);
+ 				}
+ 			}
+
 diff -rupN cnijfilter-source-3.80-1.orig/cngpijmnt/src/main.c cnijfilter-source-3.80-1/cngpijmnt/src/main.c
---- cnijfilter-source-3.80-1.orig/cngpijmnt/src/main.c	2012-04-26 12:49:34.000000000 +0300
-+++ cnijfilter-source-3.80-1/cngpijmnt/src/main.c	2014-12-13 17:38:12.000000000 +0200
+--- cnijfilter-source-3.80-1.orig/cngpijmnt/src/main.c	2012-04-26 13:49:34.000000000 +0400
++++ cnijfilter-source-3.80-1/cngpijmnt/src/main.c	2020-12-05 21:02:48.014581853 +0300
 @@ -21,7 +21,10 @@
  #include	<config.h>
  #endif	// HAVE_CONFIG_H
@@ -34,6 +99,71 @@ diff -rupN cnijfilter-source-3.80-1.orig/cngpijmnt/src/main.c cnijfilter-source-
  #include <cups/language.h>
  #include <cups/ppd.h>
  #include <unistd.h>
+@@ -320,10 +323,10 @@ static short getDeviceURI( const char *p
+ 	}
+ 	else {
+ 		pRequest = ippNew();
+-
+-		pRequest->request.op.operation_id = CUPS_GET_PRINTERS;
+-		pRequest->request.op.request_id   = 1;
+-
++
++		ippSetOperation(pRequest, CUPS_GET_PRINTERS);
++		ippSetRequestId(pRequest, 1);
++
+ 		pLanguage = bjcupsLangDefault();	// cupsLangDefault() -> bjcupsLangDefault() for cups-1.1.19
+
+ 		ippAddString(pRequest, IPP_TAG_OPERATION, IPP_TAG_CHARSET, "attributes-charset", NULL, cupsLangEncoding(pLanguage));
+@@ -331,29 +334,29 @@ static short getDeviceURI( const char *p
+ 		ippAddString(pRequest, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri", NULL, NULL);
+
+ 		if ((pResponse = cupsDoRequest(pHTTP, pRequest, "/")) != NULL) {
+-			if (pResponse->request.status.status_code > IPP_OK_CONFLICT) {
++			if (ippGetStatusCode(pResponse) > IPP_OK_CONFLICT) {
+ 				fputs("ERROR: IPP ERROR\n", stderr);
+ 				goto onErr;
+ 			}
+ 			else {
+-				pAttribute = pResponse->attrs;
++				pAttribute = ippFirstAttribute(pResponse);
+
+ 				while (pAttribute != NULL) {
+-					while (pAttribute != NULL && pAttribute->group_tag != IPP_TAG_PRINTER) {
+-						pAttribute = pAttribute->next;
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) != IPP_TAG_PRINTER) {
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+ 					if (pAttribute == NULL) {
+ 						break;
+ 					}
+-
+-					while (pAttribute != NULL && pAttribute->group_tag == IPP_TAG_PRINTER) {
+-						if (strcmp(pAttribute->name, "printer-name") == 0 && pAttribute->value_tag == IPP_TAG_NAME) {
+-							pPrinter = pAttribute->values[0].string.text;
++
++					while (pAttribute != NULL && ippGetGroupTag(pAttribute) == IPP_TAG_PRINTER) {
++						if (strcmp(ippGetName(pAttribute), "printer-name") == 0 && ippGetValueTag(pAttribute) == IPP_TAG_NAME) {
++							pPrinter = ippGetString(pAttribute, 0, pLanguage);
+ 						}
+-						if (strcmp(pAttribute->name, "device-uri") == 0 && pAttribute->value_tag == IPP_TAG_URI) {
+-							pDUri = pAttribute->values[0].string.text;
++						if (strcmp(ippGetName(pAttribute), "device-uri") == 0 && ippGetValueTag(pAttribute)  == IPP_TAG_URI) {
++							pDUri = ippGetString(pAttribute, 0, pLanguage);
+ 						}
+-						pAttribute = pAttribute->next;
++						pAttribute = ippNextAttribute(pResponse);
+ 					}
+
+ 					if (strcasecmp(pDestName, pPrinter) == 0) {
+@@ -362,7 +365,7 @@ static short getDeviceURI( const char *p
+ 					}
+
+ 					if (pAttribute != NULL)
+-						 pAttribute = pAttribute->next;
++						pAttribute = ippNextAttribute(pResponse);
+ 				}
+ 			}
+
 diff -rupN cnijfilter-source-3.80-1.orig/cngpijmon/src/bjcupsmon_cups.c cnijfilter-source-3.80-1/cngpijmon/src/bjcupsmon_cups.c
 --- cnijfilter-source-3.80-1.orig/cngpijmon/src/bjcupsmon_cups.c	2012-05-22 12:49:27.000000000 +0300
 +++ cnijfilter-source-3.80-1/cngpijmon/src/bjcupsmon_cups.c	2014-12-13 17:25:16.000000000 +0200
@@ -80,3 +210,21 @@ diff -rupN cnijfilter-source-3.80-1.orig/cnijfilter/src/bjfimage.c cnijfilter-so
  	{
  		png_destroy_read_struct(&png_p, &info_p, (png_infopp)NULL);
  		goto onErr;
+diff -rupN cnijfilter-source-3.80-1.orig/debian/compat cnijfilter-source-3.80-1/debian/compat
+--- cnijfilter-source-3.80-1.orig/debian/compat	2012-03-29 08:50:27.000000000 +0400
++++ cnijfilter-source-3.80-1/debian/compat	2020-12-05 16:33:06.915532831 +0300
+@@ -1 +1 @@
+-4
++5
+diff -rupN cnijfilter-source-3.80-1.orig/debian/control cnijfilter-source-3.80-1/debian/control
+--- cnijfilter-source-3.80-1.orig/debian/control	2012-03-29 08:50:27.000000000 +0400
++++ cnijfilter-source-3.80-1/debian/control	2020-12-05 17:03:14.138334713 +0300
+@@ -2,7 +2,7 @@ Source: cnijfilter-common
+ Section: graphics
+ Priority: optional
+ Maintainer: Canon Inc. <sup-debian@list.canon.co.jp>
+-Build-Depends: debhelper (>= 4.0.0), libcupsys2-dev, libxml2-dev, libtiff4-dev
++Build-Depends: debhelper (>= 4.0.0), libcups2-dev, libxml2-dev, libtiff-dev, libgtk2.0-dev, libpopt-dev
+ Standards-Version: 3.7.2
+
+ Package: cnijfilter-common


### PR DESCRIPTION
Hi!

I recently tried to install the drivers from [canon](https://www.canon-europe.com/support/consumer_products/products/fax__multifunctionals/inkjet/pixma_mp_series/pixma_mp230.html?type=drivers&language=en&os=linux%20(64-bit)) on ubuntu focal, but couldn't because of package deps incompatibility. Tried to build it from source but failed again due to compilation errors. I came across your patch and it helped me on my way to building the driver.

Here I'm updating the use of  [libcups](https://www.cups.org/doc/cupspm.html) so that all the packages build properly. At leas for me on ubuntu using debuild it worked out